### PR TITLE
fsnotify Ops - Adding support for fil closure events Ticket #: EM-1861

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -29,6 +29,9 @@ const (
 	Remove
 	Rename
 	Chmod
+	CloseWrite
+	CloseNoWrite
+	Modify
 )
 
 func (op Op) String() string {
@@ -49,6 +52,15 @@ func (op Op) String() string {
 	}
 	if op&Chmod == Chmod {
 		buffer.WriteString("|CHMOD")
+	}
+	if op&CloseWrite == CloseWrite {
+		buffer.WriteString("|CLOSE_WRITE")
+	}
+	if op&CloseNoWrite == CloseNoWrite {
+		buffer.WriteString("|CLOSE_NO_WRITE")
+	}
+	if op&Modify == Modify {
+		buffer.WriteString("|MODIFY")
 	}
 	if buffer.Len() == 0 {
 		return ""

--- a/inotify.go
+++ b/inotify.go
@@ -98,7 +98,8 @@ func (w *Watcher) Add(name string) error {
 
 	const agnosticEvents = unix.IN_MOVED_TO | unix.IN_MOVED_FROM |
 		unix.IN_CREATE | unix.IN_ATTRIB | unix.IN_MODIFY |
-		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF
+		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF |
+		unix.IN_CLOSE_WRITE | unix.IN_CLOSE_NOWRITE
 
 	var flags uint32 = agnosticEvents
 
@@ -322,13 +323,19 @@ func newEvent(name string, mask uint32) Event {
 		e.Op |= Remove
 	}
 	if mask&unix.IN_MODIFY == unix.IN_MODIFY {
-		e.Op |= Write
+		e.Op |= Modify
 	}
 	if mask&unix.IN_MOVE_SELF == unix.IN_MOVE_SELF || mask&unix.IN_MOVED_FROM == unix.IN_MOVED_FROM {
 		e.Op |= Rename
 	}
 	if mask&unix.IN_ATTRIB == unix.IN_ATTRIB {
 		e.Op |= Chmod
+	}
+	if mask&unix.IN_CLOSE_WRITE == unix.IN_CLOSE_WRITE {
+		e.Op |= CloseWrite
+	}
+	if mask&unix.IN_CLOSE_NOWRITE == unix.IN_CLOSE_NOWRITE {
+		e.Op |= CloseNoWrite
 	}
 	return e
 }


### PR DESCRIPTION
Root Cause Analysis: fsnotify does not provide event notification when a file that was
opened for write is closed and actually modified.

Fix/Implementation: Add support for CLose_Write and Close_NoWrite events.  Also separate out
Modify from Write.  Modify is triggered when a file is actually modified and Write can be
triggered when a file is simply opened for write.

Reviewed By: Amy Chang